### PR TITLE
Refactor import paths and file extensions

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,5 +1,6 @@
 import { Gabarito } from "next/font/google";
 import Navbar from "../components/Navbar";
+import '../app/globals.css'
 
 const gabarito = Gabarito({
   subsets: ["latin"],

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,26 +1,28 @@
-import Navbar from '@/components/Navbar'
-import '@/app/globals.css'
-import { Gabarito } from 'next/font/google'
+import { Gabarito } from "next/font/google";
+import Navbar from "../components/Navbar";
 
 const gabarito = Gabarito({
   subsets: ["latin"],
   display: "swap",
-   weight: ["500", "600", "700", "900"], 
-   style: ["normal"],
-  })
+  weight: ["500", "600", "700", "900"],
+  style: ["normal"],
+});
 
 export const metadata = {
-  title: 'CuyAnimeList',
-  description: 'Website Anime Indonesia',
-}
+  title: "CuyAnimeList",
+  description: "Website Anime Indonesia",
+};
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className={`${gabarito.className} bg-color-dark`} suppressHydrationWarning={true}>
+      <body
+        className={`${gabarito.className} bg-color-dark`}
+        suppressHydrationWarning={true}
+      >
         <Navbar />
         {children}
       </body>
     </html>
-  )
+  );
 }

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,7 +1,7 @@
 
-import AnimeList from "@/components/AnimeList"
-import Header from "@/components/AnimeList/Header"
-import { getAnimeResponse, getNestedAnimeResponse, reproduce } from "@/libs/api-libs"
+import AnimeList from "../components/AnimeList"
+import Header from "../components/AnimeList/Header.jsx"
+import { getAnimeResponse, getNestedAnimeResponse, reproduce } from "../libs/api-libs.js"
 
 const Page = async () => {
   const topAnime = await getAnimeResponse("top/anime", "limit=8")


### PR DESCRIPTION
In this commit, update import paths and file extensions for improved consistency and readability. Specifically:

- In `page.jsx`:
  - Change imports from "@/components/AnimeList" to "../components/AnimeList"
  - Update import of `Header` from "@/components/AnimeList/Header" to "../components/AnimeList/Header.jsx"
  - Adjust imports from "@/libs/api-libs" to "../libs/api-libs.js"

- In `layout.jsx`:
  - Modify import of `Navbar` from '@/components/Navbar' to '../components/Navbar'
  - Update import of `Gabarito` from 'next/font/google' to "next/font/google"

These changes enhance code organization and adhere to a consistent import style.

### Result Preview
![image](https://github.com/Babangzhan12/WebAnimeTemplate/assets/71019245/363b0d9e-b25e-44ae-a2b9-816c8b4f57e7)
